### PR TITLE
add --useType flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ enum Role {
 ```typescript
 export enum Role {
   USER = 'USER',
-  ADMIN = 'ADMIN'
+  ADMIN = 'ADMIN',
 }
 
 export interface User {
@@ -82,13 +82,13 @@ export interface User {
 }
 
 export interface Post {
-  id: number
-  createdAt: Date
-  updatedAt: Date
-  published: boolean
-  title: string
-  author?: User
-  authorId?: number
+  id: number,
+  createdAt: Date,
+  updatedAt: Date,
+  published: boolean,
+  title: string,
+  author?: User,
+  authorId?: number,
 }
 ```
 
@@ -97,24 +97,24 @@ export interface Post {
 ```typescript
 export enum Role {
   USER = 'USER',
-  ADMIN = 'ADMIN'
+  ADMIN = 'ADMIN',
 }
 
 export interface User {
-  id?: number
-  createdAt?: Date | string
-  email: string
-  name?: string
-  role?: Role
+  id?: number,
+  createdAt?: (Date | string),
+  email: string,
+  name?: string | null,
+  role?: Role,
 }
 
 export interface Post {
-  id?: number
-  createdAt?: Date | string
-  updatedAt: Date | string
-  published?: boolean
-  title: string
-  authorId?: number
+  id?: number,
+  createdAt?: (Date | string),
+  updatedAt: (Date | string),
+  published?: boolean,
+  title: string,
+  authorId?: number | null,
 }
 ```
 
@@ -123,25 +123,25 @@ export interface Post {
 ```typescript
 export enum Role {
   USER = 'USER',
-  ADMIN = 'ADMIN'
+  ADMIN = 'ADMIN',
 }
 
 export type User = {
-  id: number
-  createdAt: Date
-  email: string
-  name?: string
-  role: Role
-  posts: Post[]
+  id: number,
+  createdAt: Date,
+  email: string,
+  name?: string,
+  role: Role,
+  posts: Post[],
 }
 
 export type Post = {
-  id: number
-  createdAt: Date
-  updatedAt: Date
-  published: boolean
-  title: string
-  author?: User
-  authorId?: number
+  id: number,
+  createdAt: Date,
+  updatedAt: Date,
+  published: boolean,
+  title: string,
+  author?: User,
+  authorId?: number,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If using this package to generate types that will be assigned to data to be inse
 - Fields marked with a `@default` value are made optional because they are populated automatically if not provided when inserting a new data row.
 - Relation fields (marked with `@relation`) are omitted because they do not exist at the database level and therefore can't be inserted. Read more about this [here](https://www.prisma.io/docs/concepts/components/prisma-schema/relations#relation-fields)
 
+### Use `type` instead of `interface`
+
+By default, types are generated as an `interface`. If your use case requires using `type` instead, use the `--useType` flag.
+
 # Example
 
 ### Input Schema
@@ -110,6 +114,34 @@ export interface Post {
   updatedAt: Date | string
   published?: boolean
   title: string
+  authorId?: number
+}
+```
+
+### Generated `index.ts` (or `index.d.ts`) with `--useType` option
+
+```typescript
+export enum Role {
+  USER = 'USER',
+  ADMIN = 'ADMIN'
+}
+
+export type User = {
+  id: number
+  createdAt: Date
+  email: string
+  name?: string
+  role: Role
+  posts: Post[]
+}
+
+export type Post = {
+  id: number
+  createdAt: Date
+  updatedAt: Date
+  published: boolean
+  title: string
+  author?: User
   authorId?: number
 }
 ```

--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -34,12 +34,13 @@ export default async function generateTypes(
   schemaPath: string,
   outputPath: string,
   generateDeclarations: boolean = false,
-  generateInsertionTypes: boolean = false
+  generateInsertionTypes: boolean = false,
+  useType: boolean = false
 ) {
   const dmmf = await getDMMF({ datamodelPath: schemaPath })
   let types = distillDMMF(dmmf, generateInsertionTypes)
   types = convertPrismaTypesToJSTypes(types, generateInsertionTypes)
-  const fileContents = createTypeFileContents(types)
+  const fileContents = createTypeFileContents(types, useType)
   writeToFile(fileContents, outputPath, generateDeclarations)
 }
 
@@ -104,7 +105,7 @@ function convertPrismaTypesToJSTypes(types: TypeTransfer, generateInsertionTypes
   }
 }
 
-function createTypeFileContents(types: TypeTransfer): string {
+function createTypeFileContents(types: TypeTransfer, useType: boolean): string {
   let fileContents = `// AUTO GENERATED FILE BY @kalissaac/prisma-typegen
 // DO NOT EDIT
 
@@ -120,7 +121,7 @@ ${prismaEnum.values.map(value => `    ${value} = '${value}',`).join('\n')}
 ${types.models
   .map(
     model => `
-export interface ${model.name} {
+export ${useType ? 'type' : 'interface'} ${model.name} ${useType ? '= ': ''}{
 ${model.fields
   .map(field => `    ${field.name}${field.required ? '' : '?'}: ${field.typeAnnotation}${field.isArray ? '[]' : ''},`)
   .join('\n')}

--- a/src/generateTypes.ts
+++ b/src/generateTypes.ts
@@ -11,12 +11,15 @@ interface TypeTransfer {
 
 interface Model {
   name: string
-  fields: {
-    name: string
-    typeAnnotation: string
-    required: boolean
-    isArray: boolean
-  }[]
+  fields: Field[]
+}
+
+interface Field {
+  name: string
+  typeAnnotation: string
+  required: boolean
+  isArray: boolean,
+  hasDefault: boolean
 }
 
 interface Enum {
@@ -40,7 +43,7 @@ export default async function generateTypes(
   const dmmf = await getDMMF({ datamodelPath: schemaPath })
   let types = distillDMMF(dmmf, generateInsertionTypes)
   types = convertPrismaTypesToJSTypes(types, generateInsertionTypes)
-  const fileContents = createTypeFileContents(types, useType)
+  const fileContents = createTypeFileContents(types, useType, generateInsertionTypes)
   writeToFile(fileContents, outputPath, generateDeclarations)
 }
 
@@ -65,8 +68,9 @@ function distillDMMF(dmmf: DMMF.Document, generateInsertionTypes: boolean): Type
         .map(f => ({
           name: f.name,
           typeAnnotation: f.type,
-          required: f.isRequired && (generateInsertionTypes ? !f.hasDefaultValue : true),
-          isArray: f.isList
+          required: f.isRequired,
+          isArray: f.isList,
+          hasDefault: f.hasDefaultValue
         }))
     })
   })
@@ -85,7 +89,7 @@ function convertPrismaTypesToJSTypes(types: TypeTransfer, generateInsertionTypes
     ['Json', 'any'],
     ['Bytes', 'Buffer']
   ])
-  PrismaTypesMap.set('DateTime', generateInsertionTypes ? 'Date | string' : 'Date')
+  PrismaTypesMap.set('DateTime', generateInsertionTypes ? '(Date | string)' : 'Date')
 
   const models = types.models.map(model => {
     const fields = model.fields.map(field => ({
@@ -105,7 +109,7 @@ function convertPrismaTypesToJSTypes(types: TypeTransfer, generateInsertionTypes
   }
 }
 
-function createTypeFileContents(types: TypeTransfer, useType: boolean): string {
+function createTypeFileContents(types: TypeTransfer, useType: boolean, generateInsertionTypes: boolean): string {
   let fileContents = `// AUTO GENERATED FILE BY @kalissaac/prisma-typegen
 // DO NOT EDIT
 
@@ -123,13 +127,19 @@ ${types.models
     model => `
 export ${useType ? 'type' : 'interface'} ${model.name} ${useType ? '= ': ''}{
 ${model.fields
-  .map(field => `    ${field.name}${field.required ? '' : '?'}: ${field.typeAnnotation}${field.isArray ? '[]' : ''},`)
+  .map(field => createFieldLine(field, generateInsertionTypes))
   .join('\n')}
 }`
   )
   .join('\n')}
 `
   return fileContents
+}
+
+function createFieldLine(field: Field, generateInsertionTypes: boolean) {
+  return generateInsertionTypes
+  ? `    ${field.name}${field.required && !field.hasDefault ? '' : '?'}: ${field.typeAnnotation}${field.isArray ? '[]' : ''}${field.required ? '' : ' | null'},`
+  : `    ${field.name}${field.required ? '' : '?'}: ${field.typeAnnotation}${field.isArray ? '[]' : ''},`
 }
 
 async function writeToFile(contents: string, outputPath: string, generateDeclarations: boolean) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ if (argv[0] === 'help' || argv[0] === '--help') {
   Options:
     --declarationsOnly          Output type declarations only instead of full TypeScript file
     --generateInsertionTypes    Output interfaces for data to be inserted to a database
+    --useType                   Use type instead of interface
   `)
   exit(0)
 }
@@ -44,12 +45,20 @@ if (argv.length < 2 || argv[1] === '--declarationsOnly') {
   schemaLocation = argv[1]
 }
 
-let declarationsOnly = argv.includes('--declarationsOnly')
-let generateInsertionTypes = argv.includes('--generateInsertionTypes')
+const declarationsOnly = argv.includes('--declarationsOnly')
+const generateInsertionTypes = argv.includes('--generateInsertionTypes')
+const useType = argv.includes('--useType')
+
 
 try {
   console.log('Generating types...')
-  await generateTypes(schemaLocation, outputPath, declarationsOnly, generateInsertionTypes)
+  await generateTypes(
+    schemaLocation,
+    outputPath,
+    declarationsOnly,
+    generateInsertionTypes,
+    useType
+  )
   console.log('Done!')
 } catch (e) {
   console.error(e)


### PR DESCRIPTION
I had a compiler error come up when trying to pass an object of the generated interface type to a function expecting a `Record<string, string | number | Date>`. Apparently this isn't supported with `interface` unless you specifically cast the key as a string, but does work with `type`.

I added a simple flag to enable generating with `type` instead of the default `interface` if it's relevant for anyone else.